### PR TITLE
[HTTPS] Temporarily disable trust on Mac OS

### DIFF
--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -222,12 +222,19 @@ namespace Microsoft.AspNetCore.DeveloperCertificates.Tools
                 reporter.Warn("Trusting the HTTPS development certificate was requested. A confirmation prompt will be displayed " +
                     "if the certificate was not previously trusted. Click yes on the prompt to trust the certificate.");
             }
+            
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && trust?.HasValue() == true)
+            {
+                reporter.Warn("Trusting the HTTPS development certificate is currently disabled. To trust the certificate manually " +
+                 "export the certificate with dotnet dev-certs https -ep <<path>> and run the following command "+
+                 "'sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain'.");
+            }
 
             var result = manager.EnsureAspNetCoreHttpsDevelopmentCertificate(
                 now,
                 now.Add(HttpsCertificateValidity),
                 exportPath.Value(),
-                trust == null ? false : trust.HasValue(),
+                (trust == null || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) ? false : trust.HasValue(),
                 password.HasValue(),
                 password.Value());
 


### PR DESCRIPTION
Temporarily disable trying to trust the certificate on Mac OS due to an issue in .NET Core that prevents it from working and blocks VS 4 Mac.

# {PR title}

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

{Detail}

Fixes #{bug number} (in this specific format)
