### PR TITLE
Use consistent case in the template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/template.json
@@ -50,7 +50,7 @@
       "type": "bind",
       "binding": "HostIdentifier"
     },
-    "Framework": {
+    "framework": {
       "type": "parameter",
       "description": "The target framework for the project.",
       "datatype": "choice",
@@ -62,7 +62,7 @@
       ],
       "defaultValue": "net7.0"
     },
-    "ExcludeLaunchSettings": {
+    "excludeLaunchSettings": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false",
@@ -118,7 +118,7 @@
       },
       "replaces": "5001"
     },
-    "UseProgramMain": {
+    "useProgramMain": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false",


### PR DESCRIPTION
Using capital letters for the options makes them consistent with other templates. Especially around `-f` and `--framework`.

# {PR title}

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

{Detail}

Fixes #{bug number} (in this specific format)
